### PR TITLE
Fix title/subtitle in README sample settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ the defaults.
 
 ```yaml
 # Settings for main header
-header:
-  title: My Octopress Blog
-  subtitle: A clever subtitle (optional)
+title: My Octopress Blog
+subtitle: A clever subtitle (optional)
  
 # Links for main navigation
 nav:


### PR DESCRIPTION
`title` and `subtitle` aren't expected to be under `header`.
`assets/config.yml` shows that they are top-level keys.
My testing also confirms this.