### PR TITLE
related to issue 12, makes index.css dynamically use center-headings

### DIFF
--- a/assets/stylesheets/index.scss
+++ b/assets/stylesheets/index.scss
@@ -1,6 +1,10 @@
 // Theme settings
 
+{% if theme.center-headings %}
+$center-headings: {{ theme.center-headings }};
+{% else %}
 $center-headings: false;
+{% endif %}
 
 // Stylesheets
 @import "colors";


### PR DESCRIPTION
See comments on issue 12, this makes index.css dynamically use center-headings with Liquid templating.