### PR TITLE
Fix gems yaml statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install manually without bundler:
 Then add the gem to your Jekyll configuration.
 
     gems:
-      -octopress-genesis-theme
+      - octopress-genesis-theme
 
 ## Usage
 


### PR DESCRIPTION
It was missing a space.

This is the cause of the confusion behind this issue IMO:  https://github.com/octopress/genesis-theme/issues/9 (I know because I did the same).

The same typo is in the other READMEs. I would be happy to open PRs for each of them but don't want to be annoying.