### PR TITLE
Updated entry metadata to be centered or left-aligned

### DIFF
--- a/assets/stylesheets/_entry.scss
+++ b/assets/stylesheets/_entry.scss
@@ -29,6 +29,12 @@
   }
 }
 
+.entry-meta {
+  @if ($center-headings) {
+    text-align: center;
+  }
+}
+
 .entry-title {
   margin-bottom: 0;
 }
@@ -109,7 +115,6 @@
 
 .entry-meta {
   display: block;
-  text-align: center;
   .entry-header + & {
     margin: 2em auto;
   }


### PR DESCRIPTION
As commented in #36 this PR makes the `entry-meta` style be conditionally centered with the same criteria as the `entry-title`.