### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ title: My Octopress Blog
 subtitle:
  
 # Links for main navigation
-nav:
+main_nav:
   - { url: '/', title: 'Posts' }
   - { url: '/archive/', title: 'Archive' }
   - { url: '/feed/', title: 'Subscribe' }


### PR DESCRIPTION
The correct variable name for the links for main navigation is now `main_nav`, not `nav` anymore.