### PR TITLE
Set title in the head metadata for each page.

### DIFF
--- a/assets/includes/head.html
+++ b/assets/includes/head.html
@@ -1,4 +1,5 @@
 <meta charset="utf-8">
+<title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 {% if site.author %}<meta name="author" content="{{ site.author }}">{% endif %}
 <meta name="HandheldFriendly" content="True">
 <meta name="MobileOptimized" content="320">


### PR DESCRIPTION
I'm new to Octopress, but it seems the theme should still be setting the Title element in the html header.  It does in the default Jekyll theme at least, and without this patch you have to jump through hoops to set it when using this default Octopress theme.
